### PR TITLE
`onChange`, `onClick` or `onBlur` callbacks should be optional in all the components

### DIFF
--- a/src/Autocomplete/Autocomplete.js
+++ b/src/Autocomplete/Autocomplete.js
@@ -207,18 +207,12 @@ export class Autocomplete extends Component {
 
   sendBlur() {
     const { name, onBlur } = this.props
-
-    if (typeof onBlur === 'function') {
-      onBlur(name)
-    }
+    onBlur(name)
   }
 
   sendChange(value) {
     const { name, onChange } = this.props
-
-    if (typeof onChange === 'function') {
-      onChange(name, value)
-    }
+    onChange(name, value)
   }
 
   searchOn() {
@@ -284,7 +278,10 @@ export class Autocomplete extends Component {
 const { array, bool, func, number, string } = PropTypes
 
 Autocomplete.defaultProps = {
-  minOptionsForSearch: Infinity
+  minOptionsForSearch: Infinity,
+  onBlur: () => {},
+  onChange: () => {},
+  onFocus: () => {}
 }
 
 Autocomplete.propTypes = {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -15,4 +15,8 @@ Button.propTypes = {
   type: string.isRequired
 }
 
+Button.defaultProps = {
+  onClick: () => {}
+}
+
 export default Button

--- a/src/Datepicker/Datepicker.js
+++ b/src/Datepicker/Datepicker.js
@@ -65,10 +65,7 @@ class Datepicker extends Component {
 
   sendBlur() {
     const { name, onBlur } = this.props
-
-    if (typeof onBlur === 'function') {
-      onBlur(name)
-    }
+    onBlur(name)
   }
 
   handleDateInputClick = () => {
@@ -157,11 +154,17 @@ const { bool, func, number, oneOfType, string } = PropTypes
 Datepicker.propTypes = {
   locale: string,
   name: string,
-  onBlur: func.isRequired,
-  onChange: func.isRequired,
+  onBlur: func,
+  onChange: func,
   onFocus: func,
   readOnly: bool,
   value: oneOfType([number, string])
+}
+
+Datepicker.defaultProps = {
+  onBlur: () => {},
+  onChange: () => {},
+  onFocus: () => {}
 }
 
 Datepicker.childContextTypes = {

--- a/src/MoneyInput/MoneyInput.js
+++ b/src/MoneyInput/MoneyInput.js
@@ -24,9 +24,7 @@ class MoneyInput extends Component {
     const { name, value: amount } = e.target
     const amountInCents = this.convertToCents(amount)
 
-    if (typeof onChange === 'function') {
-      onChange(name, amountInCents)
-    }
+    onChange(name, amountInCents)
   }
 
   handleClick = e => {
@@ -133,6 +131,8 @@ MoneyInput.defaultProps = {
   currencySymbol: '$',
   decimalMark: '.',
   maxLength: 10,
+  onBlur: () => {},
+  onChange: () => {},
   subunitToUnit: 100,
   symbolFirst: true,
   thousandsSeparator: ','

--- a/src/PhoneInput/PhoneInput.js
+++ b/src/PhoneInput/PhoneInput.js
@@ -23,10 +23,7 @@ class PhoneInput extends Component {
 
   handleBlur = () => {
     const { name, onBlur } = this.props
-
-    if (typeof onBlur === 'function') {
-      onBlur(name)
-    }
+    onBlur(name)
   }
 
   handleChange = e => {
@@ -93,9 +90,7 @@ class PhoneInput extends Component {
   sendChange(value) {
     const { name, onChange } = this.props
 
-    if (typeof onChange === 'function') {
-      onChange(name, value)
-    }
+    onChange(name, value)
   }
 
   render() {
@@ -142,6 +137,12 @@ PhoneInput.propTypes = {
   onFocus: func,
   readOnly: bool,
   value: string
+}
+
+PhoneInput.defaultProps = {
+  onBlur: () => {},
+  onChange: () => {},
+  onFocus: () => {}
 }
 
 export default PhoneInput

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -30,4 +30,9 @@ Select.propTypes = {
   values: array.isRequired
 }
 
+Select.defaultProps = {
+  onChange: () => {},
+  onClick: () => {}
+}
+
 export default Select

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -15,17 +15,14 @@ class TextInput extends Component {
     const { onBlur } = this.props
     const { name } = e.target
 
-    if (typeof onBlur === 'function') {
-      onBlur(name)
-    }
+    onBlur(name)
   }
 
   handleChange = e => {
     const { onChange } = this.props
     let { name, value } = e.target
-    if (typeof onChange === 'function') {
-      onChange(name, value)
-    }
+
+    onChange(name, value)
     this.setState({ value })
   }
 
@@ -75,4 +72,8 @@ TextInput.propTypes = {
   value: string
 }
 
+TextInput.defaultProps = {
+  onBlur: () => {},
+  onChange: () => {}
+}
 export default TextInput


### PR DESCRIPTION
Some components, f.e the `Select`, force to define the  `onChange`, `onClick` or `onBlur`. This callback should be optional.