### PR TITLE
Remove Alert component test exclusivity

### DIFF
--- a/src/Alert/Alert-test.js
+++ b/src/Alert/Alert-test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import Alert from './Alert'
 
-describe.only('Alert', () => {
+describe('Alert', () => {
   class AlertComponent {
     constructor({ children, ...ownProps }) {
       const defaultProps = {}


### PR DESCRIPTION
I cloned the project and run ``make test``. I only saw two tests passing:

![screen shot 2017-05-10 at 7 02 01 pm](https://cloud.githubusercontent.com/assets/33331/25911181/2eb2fc3c-35b3-11e7-8116-0238c9c74b9f.png)

That was suspicious, given that we have a lot more test cases.

By setting the mocha reporter to ``spec``, I found out that the test runner was stopping in Alert, and that is when I spotted the ``describe.only`` call in Alert-test.js https://github.com/peertransfer/flycomponents/blob/master/src/Alert/Alert-test.js#L6