### PR TITLE
PhoneInput removes remaining text

### DIFF
--- a/src/PhoneInput/PhoneInput.js
+++ b/src/PhoneInput/PhoneInput.js
@@ -12,13 +12,17 @@ class PhoneInput extends Component {
 
     const { value = NO_VALUE } = this.props
     const { value: isoCode, phonePattern } = this.getCountryFrom(value)
-    const formattedNumber = applyPattern(value, phonePattern)
+    const formattedNumber = this.formatNumber(value, phonePattern)
 
     this.state = {
       formattedNumber,
       preferredCountryIsoCode: null,
       selectedCountry: isoCode
     }
+  }
+
+  formatNumber(value, phonePattern) {
+    return applyPattern(value, phonePattern, { ignoreExcedingText: false })
   }
 
   handleBlur = () => {
@@ -35,7 +39,7 @@ class PhoneInput extends Component {
     phoneNumber = phoneNumber.replace(/(?!^\+)\D/gm, '')
 
     if (phonePattern) {
-      phoneNumber = applyPattern(phoneNumber, phonePattern)
+      phoneNumber = this.formatNumber(phoneNumber, phonePattern)
     }
 
     this.setState(() => {
@@ -61,7 +65,7 @@ class PhoneInput extends Component {
     this.setState({
       preferredCountryIsoCode: isoCode,
       selectedCountry: isoCode,
-      formattedNumber: applyPattern(phoneNumber, phonePattern)
+      formattedNumber: this.formatNumber(phoneNumber, phonePattern)
     })
   }
 

--- a/src/utils/formatter/formatter-test.js
+++ b/src/utils/formatter/formatter-test.js
@@ -19,7 +19,7 @@ describe('applyPattern', () => {
 
   it('returns a formatted text', () => {
     const pattern = '+. (...) ...-....'
-    const text = applyPattern('166666666666', pattern)
+    const text = applyPattern('16666666666', pattern)
     const expectedText = '+1 (666) 666-6666'
 
     expect(text).to.equal(expectedText)
@@ -34,9 +34,19 @@ describe('applyPattern', () => {
   })
 
   it('ignores exceding text', () => {
-    const pattern = '...'
-    const text = applyPattern('12345', pattern)
-    const expectedText = '123'
+    const pattern = '../../....'
+    const text = applyPattern('121220120', pattern)
+    const expectedText = '12/12/2012'
+
+    expect(text).to.equal(expectedText)
+  })
+
+  it('appends exceding text', () => {
+    const pattern = '../../....'
+    const text = applyPattern('121220120', pattern, {
+      ignoreExcedingText: false
+    })
+    const expectedText = '12/12/20120'
 
     expect(text).to.equal(expectedText)
   })

--- a/src/utils/formatter/formatter.js
+++ b/src/utils/formatter/formatter.js
@@ -1,7 +1,9 @@
-export const applyPattern = (text, pattern) => {
+export const applyPattern = (text, pattern, options = {}) => {
   if (text.length === 0 || !pattern) return text
 
   const sanitizedText = text.replace(/\D/g, '')
+  const defaults = { ignoreExcedingText: true }
+  const settings = { ...defaults, ...options }
 
   const formattedObject = pattern.split('').reduce((acc, character) => {
     if (acc.remainingText.length === 0) {
@@ -21,5 +23,7 @@ export const applyPattern = (text, pattern) => {
     }
   }, { formattedText: '', remainingText: sanitizedText.split('') })
 
-  return formattedObject.formattedText
+  return settings.ignoreExcedingText
+    ? formattedObject.formattedText
+    : formattedObject.formattedText + formattedObject.remainingText.join('')
 }


### PR DESCRIPTION
For example, if you try to write +86156618925190, it is formatted as +86 15-661892519, removing the last 0, resulting in an invalid phone number.