### PR TITLE
Make TextInput pass only the props supported by its children

### DIFF
--- a/docs/src/components/TextInput/TextInput.js
+++ b/docs/src/components/TextInput/TextInput.js
@@ -1,10 +1,40 @@
 import React from 'react'
-import { TextInput } from '../../../../src'
+import { TextInput, FormGroup } from '../../../../src'
 import Component from '../Component'
 import README from './README.md'
 
 export default () => (
   <Component readme={README}>
-    <TextInput name="twitter" prefix="@" />
+    <FormGroup name="default" label="Default" className="FormGroup GridColumn">
+      <TextInput name="default" />
+    </FormGroup>
+    <FormGroup
+      name="withprefix"
+      label="With prefix"
+      className="FormGroup GridColumn"
+    >
+      <TextInput name="withprefix" prefix="@" />
+    </FormGroup>
+    <FormGroup
+      name="withsufix"
+      label="With sufix"
+      className="FormGroup GridColumn"
+    >
+      <TextInput name="withsufix" sufix=".com" />
+    </FormGroup>
+    <FormGroup
+      name="withvalue"
+      label="With value"
+      className="FormGroup GridColumn"
+    >
+      <TextInput name="withvalue" value="Preset value" />
+    </FormGroup>
+    <FormGroup
+      name="multiline"
+      label="Multiline"
+      className="FormGroup GridColumn"
+    >
+      <TextInput name="multiline" multiline={true} />
+    </FormGroup>
   </Component>
 )

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -26,32 +26,63 @@ class TextInput extends Component {
     this.setState({ value })
   }
 
-  render() {
-    const { value } = this.state
+  fieldValue() {
+    return this.state.value
+  }
+
+  textArea() {
     const { multiline, prefix, sufix, ...inputAttrs } = this.props
 
+    return (
+      <Textarea
+        {...inputAttrs}
+        onBlur={this.handleBlur}
+        onChange={this.handleChange}
+        value={this.fieldValue()}
+      />
+    )
+  }
+
+  inputGroup() {
+    const { multiline, prefix, sufix, ...inputAttrs } = this.props
+
+    return (
+      <InputGroup
+        {...inputAttrs}
+        onBlur={this.handleBlur}
+        onChange={this.handleChange}
+        prefix={prefix}
+        sufix={sufix}
+        type="text"
+        value={this.fieldValue()}
+      />
+    )
+  }
+
+  input() {
+    const { multiline, sufix, prefix, ...inputAttrs } = this.props
+
+    return (
+      <Input
+        {...inputAttrs}
+        onBlur={this.handleBlur}
+        onChange={this.handleChange}
+        type="text"
+        value={this.fieldValue()}
+      />
+    )
+  }
+
+  render() {
+    const { multiline, prefix, sufix } = this.props
+
     if (multiline) {
-      return (
-        <Textarea
-          {...inputAttrs}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          value={value}
-        />
-      )
+      return this.textArea()
+    }
+    if (sufix || prefix) {
+      return this.inputGroup()
     } else {
-      const Tag = sufix || prefix ? InputGroup : Input
-      return (
-        <Tag
-          {...inputAttrs}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          prefix={prefix}
-          sufix={sufix}
-          type="text"
-          value={value}
-        />
-      )
+      return this.input()
     }
   }
 }


### PR DESCRIPTION
Warnings where shown in the console because TextInput was passing props not supported by the underlying components. 

For example: when sufix was passed the <input /> component underneath was getting that prop:

<img width="925" alt="screen shot 2017-06-01 at 2 01 32 pm" src="https://cloud.githubusercontent.com/assets/33331/26678861/d8447336-46d2-11e7-84a3-3ec8f0b04ec2.png">

What I've done in this patch is to extract each of the components TextInput was rendering into query methods so we control the props that are given in each case. I've also added each use case to the examples in the docs of TextInput.