### PR TITLE
Pass defaultValue to input when value property is given to Input

### DIFF
--- a/src/Input/Input-test.js
+++ b/src/Input/Input-test.js
@@ -37,4 +37,22 @@ describe('Input', () => {
 
     expect(component.input().prop('readOnly')).to.be.true
   })
+
+  context('when value property is given', () => {
+    it('sets default value', () => {
+      const component = componentWithValue('Something')
+
+      expect(component.input().prop('defaultValue')).to.equal('Something')
+    })
+
+    it('never sets value property', () => {
+      const component = componentWithValue()
+
+      expect(component.input().prop('value')).to.be.undefined
+    })
+
+    function componentWithValue(value = 'anything') {
+      return new InputComponent({ value })
+    }
+  })
 })

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Input = ({ name, required, type, ...other }) => (
+const Input = ({ name, required, type, value, ...other }) => (
   <input
     autoComplete="off"
     className="Input"
@@ -9,6 +9,7 @@ const Input = ({ name, required, type, ...other }) => (
     name={name}
     required={required}
     type={type}
+    defaultValue={value}
     {...other}
   />
 )


### PR DESCRIPTION
Warnings where shown in the console when changing the value of an Input component:

![screen shot 2017-06-01 at 7 25 09 pm](https://cloud.githubusercontent.com/assets/33331/26692198/15e98956-4700-11e7-84eb-45fac267167e.png)

I found that was warning was shown because Input was passing value as property to a HTML form ``input`` component and value is not supposed to change unless that is controlled (via a callback passed as onChange). 

My guess by reading the documentation of TextInput is that if we pass the value property to Input is because that is a default value that we expect to change, so in this patch what I've done is to pass ``value`` from ``Input`` to ``input`` as ``defaultValue``.