### PR TITLE
Moment library is included in the js bundle

### DIFF
--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -80,6 +80,10 @@ function buildConfig () {
       }),
       new webpack.optimize.OccurrenceOrderPlugin(),
       new webpack.optimize.AggressiveMergingPlugin(),
+      new webpack.ContextReplacementPlugin(
+        /moment[\/\\]locale$/,
+        /en|es|fr|ja|ko|pt|zh-cn/
+      )
     ],
     module: {
       rules: [


### PR DESCRIPTION
Moment lib is being included in the js bundle although it is configured in the webpack's externals.

![screen shot 2017-05-04 at 23 11 42](https://cloud.githubusercontent.com/assets/767/25725152/11b15950-311f-11e7-9e68-86a368d1fd0e.png)

